### PR TITLE
small fix for is_A class method

### DIFF
--- a/LCS.lua
+++ b/LCS.lua
@@ -138,8 +138,10 @@ Class = function(members)
     assert(isA(self,'object'),'is_A() must be called from an object')
     if aClass then
       assert(isA(aClass,'class'),'When given, Argument must be a class')
+      return self:getClass() == aClass
+    else
+      return self:getClass()
     end
-    return (aClass and self:getClass() == aClass or self:getClass())
   end
 
   return setmetatable(newClass,baseClassMt)


### PR DESCRIPTION
the original expression would incorrectly return self:getClass() even when aClass was false if self:getClass() == aClass is false; this is also easier to read
